### PR TITLE
Korean bitcoin trader rescued in Batangas, Philippines

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,3 +189,4 @@ Readers may be interested in this relevant presentation: ["The Hodlguard- a prim
 | January 5, 2025 | Russian Man | Phuket, Thailand | [Man attacked and tied up in hotel, refuses to give up phone password, is knocked out and has cash stolen.](https://archive.is/eI12f)
 | January 13, 2025 | Miami Jeweler | Miami, Florida | [Gang of 4 men arrested by FBI on their way to rob jeweler of $2M.](https://www.local10.com/news/local/2025/01/15/feds-arrest-goons-they-say-plotted-to-kidnap-rob-miami-jeweler-one-good-bop-should-do-it/)
 | January 14, 2025 | Masis Erkol | Pattaya, Thailand | [Man tied up in condo, forced to transfer $290,000 in cryptocurrency.](https://archive.is/ktr2P)
+| January 20, 2025 | Taehwa Kim | Makati, Philippines | [Korean bitcoin trader rescued in Batangas](https://archive.is/FbOdh)


### PR DESCRIPTION
CAMP VICENTE LIM, Laguna, Philippines — A Korean engaged in Bitcoin trading was rescued by village watchmen after his alleged kidnappers abandoned him in Barangay Mayasang, Lemery, Batangas on Saturday.

In his statement to police investigators, Taehwa Kim, 40, met with an alias JC, who wanted to buy his Lamborghini Urus, at his condominium in Makati City on Wednesday.

The two went for a test drive and stopped at a spa to wait for JC’s lawyer. However, three men forced him to another vehicle where he was blindfolded and his hands tied.

Kim said he was held for three days before getting abandoned in Lemery. Aside from losing his car, Kim said the men took his Rolex watch, an ATM card and the keys to his condominium unit.

The Korean still had his hands tied when found walking by several Barangay Mayasang tanods.